### PR TITLE
v4.9.5

### DIFF
--- a/src/Support/Concerns/HandlesSeeding.php
+++ b/src/Support/Concerns/HandlesSeeding.php
@@ -21,6 +21,7 @@ trait HandlesSeeding
 
         $seeders = collect($serviceProvider->seederFilePaths())
             ->map(fn ($path) => [str($path)->after('seeders/')->before('.php')->value() => $path])
+            ->collapse()
             ->toArray();
 
         $namespace = $serviceProvider->packageNamespace();


### PR DESCRIPTION
- [[v4.9.5] Fixed the seeder files array construction](https://github.com/VPremiss/Crafty/commit/d02d238ef35b263e1c2884fc85b64f5ef17b8ebf)